### PR TITLE
Allow styling of parent container

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you search for react native scroll indicator on npm, there are more than 10 p
   - Indicator shrinking in iOS when user scrolls beyond the edge
   - `inverted={true}` in `FlatList`
   - Indicator customization just like a regular `View` (e.g. color, width, position, etc.)
-  - Draggable indicator (added in v0.3.0)
+  - Draggable indicator (_added in v0.3.0_)
 - Detailed documentation with comprehensive examples
 - The animation logic of the indicator is well documented in the source code.
 
@@ -44,15 +44,14 @@ const App = () => {
         alignItems: 'center',
       }}
     >
-      <View
-        style={{
-          height: '30%',
-          width: '80%',
-          borderWidth: 1,
-          borderColor: 'black',
-        }}
-      >
-        <ScrollViewIndicator indStyle={{backgroundColor: 'green'}}>
+      <View style={{height: '30%', width: '80%'}}>
+        <ScrollViewIndicator
+          indStyle={{backgroundColor: 'green'}}
+          containerStyle={{
+            borderWidth: 1,
+            borderColor: 'black',
+          }}
+        >
           <View>
             <Text>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
@@ -103,8 +102,6 @@ const App = () => {
         style={{
           height: '10%',
           width: '80%',
-          borderWidth: 1,
-          borderColor: 'black',
         }}
       >
         <FlatListIndicator
@@ -130,6 +127,7 @@ const App = () => {
           horizontal={true}
           position="bottom"
           indStyle={{width: 30}}
+          containerStyle={{borderWidth: 1, borderColor: 'black'}}
         />
       </View>
     </View>
@@ -191,14 +189,15 @@ The example app is running from [`./example/App.tsx`](./example/App.tsx)
 
 ## Props
 
-| Props               | Type                                 | Defult                                | Note                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------- | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| horizontal          | boolean                              | `false`                               | If false, vertical scrolling. If true, horizontal scrolling.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| position            | string \| number                     | `''`                                  | Desired position of the indicator. One can supply "left" or "right" for vertical scrolling, in which case the indicator will be placed at the left or right edge of the view. The same goes for "top" or "bottom" for horizontal scrolling. In addition, one can supply a number, which indicates where in the view the indicator's center line (along the scrolling direction) will be located. For example, `position={20} horizontal={false}` would place the center line of the indicator at 20% of the view's width from its left edge. `position={80} horizontal={true}` would place the center line of the indicator at 80% of the view's height from its top edge. If the indicator's girth is too big such that if its center line is placed at the desired location, the indicator would overflow outside the edge, the position will be automatically clamped to ensure no overflow takes place. This is demonstrated in the comprehensive example when the "Crazy" option is selected. If supplied an empty string, the position is automatically assigned to `"right"` if vertical scrolling, or `"bottom"` if horizontal scrolling. |
-| persistentScrollbar | boolean                              | `false`                               | If false, scroll indicator does not show if the content can fit the view. If true, scroll indicator shows under all circumstances.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| indStyle            | ViewStyle                            | `{backgroundColor: 'grey', width: 5}` | Styling of the scroll indicator. The scroll indicator is just an `Animated.View`. Thus, any props that modifies a `View` can potentially modify the appearance of the scroll indicator. Note that `width` refers to the girth of the indicator, which is width in vertical scrolling but height in horizontal scrolling. `borderRadius` value will be derived from the `width` prop to make it round (i.e., half the value of `width`) if not overridden. Please do not assign the following props, as they will be overwritten and won't have any effect: `position`, `height`, `transform`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| scrollViewProps     | ScrollViewProps                      | `{}`                                  | `ScrollViewIndicator` only. Props to pass to the underlying `ScrollView`. Please do not pass the following props, as they will be overwritten and won't have any effect: `horizontal`, `showsVerticalScrollIndicator`, `showsHorizontalScrollIndicator`, `onContentSizeChange`, `onLayout`, `scrollEventThrottle`, `onScroll`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| flatListProps       | ScrollViewProps & FlatListProps<any> | **required**                          | `FlatListIndicator` only. Props to pass to the underlying `FlatList`. This is a required prop, as one must supply `data` and `renderItem` to `FlatList`. Please do not pass the following props, as they will be overwritten and won't have any effect: `horizontal`, `showsVerticalScrollIndicator`, `showsHorizontalScrollIndicator`, `onContentSizeChange`, `onLayout`, `scrollEventThrottle`, `onScroll`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Props | Type | Default | Note |
+|||||
+| horizontal | boolean | `false` | If false, vertical scrolling. If true, horizontal scrolling. |
+| position | string \| number | `''` | Desired position of the indicator. One can supply "left" or "right" for vertical scrolling, in which case the indicator will be placed at the left or right edge of the view. The same goes for "top" or "bottom" for horizontal scrolling. In addition, one can supply a number, which indicates where in the view the indicator's center line (along the scrolling direction) will be located. For example, `position={20} horizontal={false}` would place the center line of the indicator at 20% of the view's width from its left edge. `position={80} horizontal={true}` would place the center line of the indicator at 80% of the view's height from its top edge. If the indicator's girth is too big such that if its center line is placed at the desired location, the indicator would overflow outside the edge, the position will be automatically clamped to ensure no overflow takes place. This is demonstrated in the comprehensive example when the "Crazy" option is selected. If supplied an empty string, the position is automatically assigned to `"right"` if vertical scrolling, or `"bottom"` if horizontal scrolling. |
+| persistentScrollbar | boolean | `false` | If false, scroll indicator does not show if the content can fit the view. If true, scroll indicator shows under all circumstances. |
+| indStyle | ViewStyle | `{backgroundColor: 'grey', width: 5}` | Styling of the scroll indicator. The scroll indicator is just an `Animated.View`. Thus, any props that modifies a `View` can potentially modify the appearance of the scroll indicator. Note that `width` refers to the girth of the indicator, which is width in vertical scrolling but height in horizontal scrolling. `borderRadius` value will be derived from the `width` prop to make it round (i.e., half the value of `width`) if not overridden. Please do not assign the following props, as they will be overwritten and won't have any effect: `position`, `height`, `transform`. |
+| scrollViewProps | ScrollViewProps | `{}` | `ScrollViewIndicator` only. Props to pass to the underlying `ScrollView`. Please do not pass the following props, as they will be overwritten and won't have any effect: `horizontal`, `showsVerticalScrollIndicator`, `showsHorizontalScrollIndicator`, `onContentSizeChange`, `onLayout`, `scrollEventThrottle`, `onScroll` |
+| flatListProps | ScrollViewProps & FlatListProps<any> | **required** | `FlatListIndicator` only. Props to pass to the underlying `FlatList`. This is a required prop, as one must supply `data` and `renderItem` to `FlatList`. Please do not pass the following props, as they will be overwritten and won't have any effect: `horizontal`, `showsVerticalScrollIndicator`, `showsHorizontalScrollIndicator`, `onContentSizeChange`, `onLayout`, `scrollEventThrottle`, `onScroll` |
+| containerStyle | ViewStyle | `{flex: 1}` | Styling of the parent container that holds both the scroll indicator and the scrollable component. _added in v0.4.0_. |
 
 ## Limitations
 
@@ -215,3 +214,7 @@ MIT
 ---
 
 Made with [create-react-native-library](https://github.com/callstack/react-native-builder-bob)
+
+```
+
+```

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -148,8 +148,7 @@ const App = () => {
         </View>
       </View>
       <View style={styles.contentContainer}>
-        <View
-          style={[styles.scrollViewContainer, { height: hori ? '20%' : '100%' }]}>
+        <>
           {comp === 'ScrollView' ? (
             <DemoScrollViewIndicator
               hori={hori}
@@ -157,6 +156,10 @@ const App = () => {
               indStyle={
                 ind === 'Crazy' ? styles.indStyleCrazy : styles.indStyleNormal
               }
+              containerStyle={{
+                height: hori ? '20%' : '100%',
+                ...styles.scrollContainer,
+              }}
               text={hori ? lorem.text.slice(0, 100) : lorem.text}
             />
           ) : (
@@ -167,10 +170,14 @@ const App = () => {
               indStyle={
                 ind === 'Crazy' ? styles.indStyleCrazy : styles.indStyleNormal
               }
+              containerStyle={{
+                height: hori ? '20%' : '100%',
+                ...styles.scrollContainer,
+              }}
               data={lorem.text.slice(0, hori ? 100 : 800).split('.')}
             />
           )}
-        </View>
+        </>
       </View>
     </View>
   );
@@ -202,7 +209,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 30,
     marginVertical: 30,
   },
-  scrollViewContainer: {
+  scrollContainer: {
     borderWidth: 1,
     borderColor: 'black',
   },

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example",
       "version": "0.0.1",
       "dependencies": {
-        "@fanchenbao/react-native-scroll-indicator": "file:../fanchenbao-react-native-scroll-indicator-0.2.2.tgz",
+        "@fanchenbao/react-native-scroll-indicator": "file:../fanchenbao-react-native-scroll-indicator-0.3.2.tgz",
         "react": "18.3.1",
         "react-native": "0.75.1"
       },
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@fanchenbao/react-native-scroll-indicator": {
-      "version": "0.2.2",
-      "resolved": "file:../fanchenbao-react-native-scroll-indicator-0.2.2.tgz",
-      "integrity": "sha512-0v2sjA1wXZHS1kRERgGN3ORc5h0Mb4AjB7x7Jx2DhLD8qlZPQsUs2F3HYfoT1IQ2Jrgf0FHxX0w8BgowF6ouow==",
+      "version": "0.3.2",
+      "resolved": "file:../fanchenbao-react-native-scroll-indicator-0.3.2.tgz",
+      "integrity": "sha512-3R3dQs2hW6bXxqyI3pM3ll90JPnJo1KuV416IknPaVH5U/ACRRlrIgmSDi6qdQoDWQr9hzz8FzBcS7KDRYnChg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16.0.0"

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "clean": "react-native-clean-project"
   },
   "dependencies": {
-    "@fanchenbao/react-native-scroll-indicator": "file:../fanchenbao-react-native-scroll-indicator-0.2.2.tgz",
+    "@fanchenbao/react-native-scroll-indicator": "file:../fanchenbao-react-native-scroll-indicator-0.3.2.tgz",
     "react": "18.3.1",
     "react-native": "0.75.1"
   },

--- a/example/src/demo/DemoFlatListIndicator.tsx
+++ b/example/src/demo/DemoFlatListIndicator.tsx
@@ -10,19 +10,20 @@
  */
 import * as React from 'react';
 import { Text, View, ViewStyle } from 'react-native';
-// import { FlatListIndicator } from '../react-native-scroll-indicator';
-import { FlatListIndicator } from '@fanchenbao/react-native-scroll-indicator';
+import { FlatListIndicator } from '../react-native-scroll-indicator';
+// import { FlatListIndicator } from '@fanchenbao/react-native-scroll-indicator';
 
 type PropsT = {
   hori: boolean;
   posi: string | number;
   inverted: boolean;
   indStyle: ViewStyle;
+  containerStyle: ViewStyle;
   data: Array<string>;
 };
 
 export const DemoFlatListIndicator = (props: PropsT) => {
-  const { hori, posi, inverted, indStyle, data } = props;
+  const { hori, posi, inverted, indStyle, containerStyle, data } = props;
 
   return (
     <FlatListIndicator
@@ -47,6 +48,7 @@ export const DemoFlatListIndicator = (props: PropsT) => {
       horizontal={hori}
       position={posi}
       indStyle={indStyle}
+      containerStyle={containerStyle}
     />
   );
 };

--- a/example/src/demo/DemoFlatListIndicator.tsx
+++ b/example/src/demo/DemoFlatListIndicator.tsx
@@ -10,8 +10,8 @@
  */
 import * as React from 'react';
 import { Text, View, ViewStyle } from 'react-native';
-import { FlatListIndicator } from '../react-native-scroll-indicator';
-// import { FlatListIndicator } from '@fanchenbao/react-native-scroll-indicator';
+// import { FlatListIndicator } from '../react-native-scroll-indicator';
+import { FlatListIndicator } from '@fanchenbao/react-native-scroll-indicator';
 
 type PropsT = {
   hori: boolean;

--- a/example/src/demo/DemoScrollViewIndicator.tsx
+++ b/example/src/demo/DemoScrollViewIndicator.tsx
@@ -10,21 +10,26 @@
  */
 import * as React from 'react';
 import { Text, View, ViewStyle } from 'react-native';
-// import { ScrollViewIndicator } from '../react-native-scroll-indicator';
-import { ScrollViewIndicator } from '@fanchenbao/react-native-scroll-indicator';
+import { ScrollViewIndicator } from '../react-native-scroll-indicator';
+// import { ScrollViewIndicator } from '@fanchenbao/react-native-scroll-indicator';
 
 type PropsT = {
   hori: boolean;
   posi: string | number;
   indStyle: ViewStyle;
+  containerStyle: ViewStyle;
   text: string;
 };
 
 export const DemoScrollViewIndicator = (props: PropsT) => {
-  const { hori, posi, indStyle, text } = props;
+  const { hori, posi, indStyle, containerStyle, text } = props;
 
   return (
-    <ScrollViewIndicator horizontal={hori} position={posi} indStyle={indStyle}>
+    <ScrollViewIndicator
+      horizontal={hori}
+      position={posi}
+      indStyle={indStyle}
+      containerStyle={containerStyle}>
       <View style={{ padding: 10 }}>
         <Text>{text}</Text>
       </View>

--- a/example/src/demo/DemoScrollViewIndicator.tsx
+++ b/example/src/demo/DemoScrollViewIndicator.tsx
@@ -10,8 +10,8 @@
  */
 import * as React from 'react';
 import { Text, View, ViewStyle } from 'react-native';
-import { ScrollViewIndicator } from '../react-native-scroll-indicator';
-// import { ScrollViewIndicator } from '@fanchenbao/react-native-scroll-indicator';
+// import { ScrollViewIndicator } from '../react-native-scroll-indicator';
+import { ScrollViewIndicator } from '@fanchenbao/react-native-scroll-indicator';
 
 type PropsT = {
   hori: boolean;

--- a/example/src/react-native-scroll-indicator/ScrollIndicator.tsx
+++ b/example/src/react-native-scroll-indicator/ScrollIndicator.tsx
@@ -10,7 +10,6 @@ import {
   FlatListProps,
   ScrollViewProps,
   View,
-  StyleSheet,
   LayoutChangeEvent,
   NativeSyntheticEvent,
   NativeScrollEvent,
@@ -25,6 +24,7 @@ type PropsT = {
   horizontal: boolean; // whether the scrolling direction is horizontal
   persistentScrollbar: boolean; // whether to persist scroll indicator
   indStyle: ViewStyle; // style of the scroll indicator
+  containerStyle: ViewStyle; // style of the parent container that holds both the indicator and the scrollable component
   children?: React.ReactNode | React.ReactNode[]; // used for ScrollView only
 };
 
@@ -36,6 +36,7 @@ export const ScrollIndicator = (props: PropsT) => {
     horizontal,
     persistentScrollbar,
     indStyle,
+    containerStyle,
   } = props;
 
   // total size of the content if rendered
@@ -156,7 +157,7 @@ export const ScrollIndicator = (props: PropsT) => {
   return (
     <View
       ref={parentRef}
-      style={stylles.parentContainer}
+      style={containerStyle}
       onLayout={() => {
         if (parentRef.current) {
           parentRef.current?.measure((_1, _2, _3, _4, pageX, pageY) => {
@@ -225,9 +226,3 @@ export const ScrollIndicator = (props: PropsT) => {
     </View>
   );
 };
-
-const stylles = StyleSheet.create({
-  parentContainer: {
-    flex: 1,
-  },
-});

--- a/example/src/react-native-scroll-indicator/index.tsx
+++ b/example/src/react-native-scroll-indicator/index.tsx
@@ -13,6 +13,7 @@ type ScrollViewPropsT = {
   horizontal?: boolean;
   persistentScrollbar?: boolean;
   indStyle?: ViewStyle;
+  containerStyle?: ViewStyle;
   scrollViewProps?: ScrollViewProps;
   children?: React.ReactNode | React.ReactNode[];
 };
@@ -23,6 +24,7 @@ export const ScrollViewIndicator = (props: ScrollViewPropsT) => {
     horizontal = false,
     persistentScrollbar = false,
     indStyle: { width = 5, ...indStyle } = {},
+    containerStyle = {},
     scrollViewProps = {},
   } = props;
 
@@ -38,6 +40,10 @@ export const ScrollViewIndicator = (props: ScrollViewPropsT) => {
         width,
         borderRadius: (width as number) / 2,
         ...indStyle,
+      }}
+      containerStyle={{
+        flex: 1,
+        ...containerStyle,
       }}>
       {props.children}
     </ScrollIndicator>
@@ -50,6 +56,7 @@ type FlatListPropsT = {
   horizontal?: boolean;
   persistentScrollbar?: boolean;
   indStyle?: ViewStyle;
+  containerStyle?: ViewStyle;
 };
 
 export const FlatListIndicator = (props: FlatListPropsT) => {
@@ -59,6 +66,7 @@ export const FlatListIndicator = (props: FlatListPropsT) => {
     horizontal = false,
     persistentScrollbar = false,
     indStyle: { width = 5, ...indStyle } = {},
+    containerStyle = {},
   } = props;
 
   return (
@@ -73,6 +81,10 @@ export const FlatListIndicator = (props: FlatListPropsT) => {
         width,
         borderRadius: (width as number) / 2,
         ...indStyle,
+      }}
+      containerStyle={{
+        flex: 1,
+        ...containerStyle,
       }}
     />
   );

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1147,10 +1147,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@fanchenbao/react-native-scroll-indicator@file:../fanchenbao-react-native-scroll-indicator-0.2.2.tgz":
-  version "0.2.2"
-  resolved "file:../fanchenbao-react-native-scroll-indicator-0.2.2.tgz"
-  integrity sha512-0v2sjA1wXZHS1kRERgGN3ORc5h0Mb4AjB7x7Jx2DhLD8qlZPQsUs2F3HYfoT1IQ2Jrgf0FHxX0w8BgowF6ouow==
+"@fanchenbao/react-native-scroll-indicator@file:../fanchenbao-react-native-scroll-indicator-0.3.2.tgz":
+  version "0.3.2"
+  resolved "file:../fanchenbao-react-native-scroll-indicator-0.3.2.tgz"
+  integrity sha512-3R3dQs2hW6bXxqyI3pM3ll90JPnJo1KuV416IknPaVH5U/ACRRlrIgmSDi6qdQoDWQr9hzz8FzBcS7KDRYnChg==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"

--- a/src/ScrollIndicator.tsx
+++ b/src/ScrollIndicator.tsx
@@ -10,7 +10,6 @@ import {
   FlatListProps,
   ScrollViewProps,
   View,
-  StyleSheet,
   LayoutChangeEvent,
   NativeSyntheticEvent,
   NativeScrollEvent,
@@ -25,6 +24,7 @@ type PropsT = {
   horizontal: boolean; // whether the scrolling direction is horizontal
   persistentScrollbar: boolean; // whether to persist scroll indicator
   indStyle: ViewStyle; // style of the scroll indicator
+  containerStyle: ViewStyle; // style of the parent container that holds both the indicator and the scrollable component
   children?: React.ReactNode | React.ReactNode[]; // used for ScrollView only
 };
 
@@ -36,6 +36,7 @@ export const ScrollIndicator = (props: PropsT) => {
     horizontal,
     persistentScrollbar,
     indStyle,
+    containerStyle,
   } = props;
 
   // total size of the content if rendered
@@ -156,7 +157,7 @@ export const ScrollIndicator = (props: PropsT) => {
   return (
     <View
       ref={parentRef}
-      style={stylles.parentContainer}
+      style={containerStyle}
       onLayout={() => {
         if (parentRef.current) {
           parentRef.current?.measure((_1, _2, _3, _4, pageX, pageY) => {
@@ -225,9 +226,3 @@ export const ScrollIndicator = (props: PropsT) => {
     </View>
   );
 };
-
-const stylles = StyleSheet.create({
-  parentContainer: {
-    flex: 1,
-  },
-});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ type ScrollViewPropsT = {
   horizontal?: boolean;
   persistentScrollbar?: boolean;
   indStyle?: ViewStyle;
+  containerStyle?: ViewStyle;
   scrollViewProps?: ScrollViewProps;
   children?: React.ReactNode | React.ReactNode[];
 };
@@ -23,6 +24,7 @@ export const ScrollViewIndicator = (props: ScrollViewPropsT) => {
     horizontal = false,
     persistentScrollbar = false,
     indStyle: { width = 5, ...indStyle } = {},
+    containerStyle = {},
     scrollViewProps = {},
   } = props;
 
@@ -38,6 +40,10 @@ export const ScrollViewIndicator = (props: ScrollViewPropsT) => {
         width,
         borderRadius: (width as number) / 2,
         ...indStyle,
+      }}
+      containerStyle={{
+        flex: 1,
+        ...containerStyle,
       }}>
       {props.children}
     </ScrollIndicator>
@@ -50,6 +56,7 @@ type FlatListPropsT = {
   horizontal?: boolean;
   persistentScrollbar?: boolean;
   indStyle?: ViewStyle;
+  containerStyle?: ViewStyle;
 };
 
 export const FlatListIndicator = (props: FlatListPropsT) => {
@@ -59,6 +66,7 @@ export const FlatListIndicator = (props: FlatListPropsT) => {
     horizontal = false,
     persistentScrollbar = false,
     indStyle: { width = 5, ...indStyle } = {},
+    containerStyle = {},
   } = props;
 
   return (
@@ -73,6 +81,10 @@ export const FlatListIndicator = (props: FlatListPropsT) => {
         width,
         borderRadius: (width as number) / 2,
         ...indStyle,
+      }}
+      containerStyle={{
+        flex: 1,
+        ...containerStyle,
       }}
     />
   );


### PR DESCRIPTION
Add new prop `containerStyle` to allow styling of the parent container that holds the indicator and the scrollable component.