### PR TITLE
Refactor ScrollIndicator to remove unnecessary parent view and stream…

### DIFF
--- a/src/ScrollIndicator.tsx
+++ b/src/ScrollIndicator.tsx
@@ -7,12 +7,12 @@ import {
   FlatList,
   ViewStyle,
   FlatListProps,
+  ScrollView,
   ScrollViewProps,
   LayoutChangeEvent,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
 import { Indicator } from './Indicator';
 import { getLocStyle } from './functions';
 


### PR DESCRIPTION
Using a View wrapper causes a lot of trouble if you simply replace it with a ScrollView. This breaks the layout, but I found a more efficient solution. I tested it, and it works.

The changes made in `ScrollIndicator.tsx` involve removing the parent view reference and simplifying the layout handling for both `FlatList` and `ScrollView`. This reduces complexity and improves performance.